### PR TITLE
Fixed GameVersions enum in Hitman2.cs, Thus adding partial GOG support.

### DIFF
--- a/Games/Hitman2.cs
+++ b/Games/Hitman2.cs
@@ -11,7 +11,7 @@ namespace HitmanStatistics
     {
         enum GameVersions
         {
-            GOG = 3006464,
+            GOG = 3076096,
             Steam
         }
 


### PR DESCRIPTION
Small patch, just one variable in an enum.
The main reason why the tracker doesn't work on the GOG version of Hitman 2: Silent Assassin was because of this enum. Changing the number to the correct one allows the game version to be detected correctly.
Everything works except for the shots fired pointer. I will fix it soon. 
The shots fired pointer still works when playing on the steam version.
I tested this on the latest GOG version at the time of writing (v1.01).
This PR does not add GOG support for Hitman: Contracts.
Also, this patch doesn't break the tracker when playing the steam version; I tested it.