### PR TITLE
I added a barely functional pointer to fix the nbShotsFiredpointer in the GOG version. It is better than nothing I suppose.

### DIFF
--- a/Games/Hitman2.cs
+++ b/Games/Hitman2.cs
@@ -152,7 +152,7 @@ namespace HitmanStatistics
                                 nbInnocentsH = Trainer.ReadPointerInteger(myProcess, baseAddress + 0x2A6C50, new int[] { 0x28, secondOffset[mapNumber - 1], 0x214 });
                                 break;
                             case GameVersions.GOG:
-                                nbShotsFired = 0;//Trainer.ReadPointerInteger(myProcess, baseAddress + 0x28B68, new int[] { 0x5C0, 0x54, 0x34 });
+                                nbShotsFired = Trainer.ReadPointerInteger(myProcess, baseAddress + 0x0003E864, new int[] { 0x3C, 0x4 }); //shit pointer. Works only up to 64, and freaks out while it does it
                                 nbCloseEncounters = Trainer.ReadPointerInteger(myProcess, baseAddress + 0x2A8C58, new int[] { 0x28, secondOffset[mapNumber - 1], 0x220 });
                                 nbHeadshots = Trainer.ReadPointerInteger(myProcess, baseAddress + 0x2A8C58, new int[] { 0x28, secondOffset[mapNumber - 1], 0x208 });
                                 nbAlerts = Trainer.ReadPointerInteger(myProcess, baseAddress + 0x2A8C58, new int[] { 0x28, secondOffset[mapNumber - 1], 0x21C });

--- a/Games/Hitman2.cs
+++ b/Games/Hitman2.cs
@@ -152,6 +152,7 @@ namespace HitmanStatistics
                                 nbInnocentsH = Trainer.ReadPointerInteger(myProcess, baseAddress + 0x2A6C50, new int[] { 0x28, secondOffset[mapNumber - 1], 0x214 });
                                 break;
                             case GameVersions.GOG:
+                                //Leaving the old pointer here for safekeeping. This one only works up to 20 and then resets. Trainer.ReadPointerInteger(myProcess, baseAddress + 0x28B68, new int[] { 0x5C0, 0x54, 0x34 });
                                 nbShotsFired = Trainer.ReadPointerInteger(myProcess, baseAddress + 0x0003E864, new int[] { 0x3C, 0x4 }); //shit pointer. Works only up to 64, and freaks out while it does it
                                 nbCloseEncounters = Trainer.ReadPointerInteger(myProcess, baseAddress + 0x2A8C58, new int[] { 0x28, secondOffset[mapNumber - 1], 0x220 });
                                 nbHeadshots = Trainer.ReadPointerInteger(myProcess, baseAddress + 0x2A8C58, new int[] { 0x28, secondOffset[mapNumber - 1], 0x208 });


### PR DESCRIPTION
Yeah, the title says it all. The new pointer only works up until 64 shots fired, and it may show absurdly large numbers in between shots. But hey, it's better than nothing. I kept the comment that contained the pointer that wasn't being used anyway. That one only works up until 20 shots fired. I guess this version of the game is coded poorly. I couldn't find a good pointer.